### PR TITLE
PoC for oras multi-arch feature support

### DIFF
--- a/cmd/oras/root/manifest/cmd.go
+++ b/cmd/oras/root/manifest/cmd.go
@@ -17,6 +17,7 @@ package manifest
 
 import (
 	"github.com/spf13/cobra"
+	"oras.land/oras/cmd/oras/root/manifest/index"
 )
 
 func Cmd() *cobra.Command {
@@ -30,6 +31,7 @@ func Cmd() *cobra.Command {
 		fetchCmd(),
 		fetchConfigCmd(),
 		pushCmd(),
+		index.Cmd(),
 	)
 	return cmd
 }

--- a/cmd/oras/root/manifest/index/cmd.go
+++ b/cmd/oras/root/manifest/index/cmd.go
@@ -1,3 +1,18 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package index
 
 import (

--- a/cmd/oras/root/manifest/index/cmd.go
+++ b/cmd/oras/root/manifest/index/cmd.go
@@ -1,0 +1,17 @@
+package index
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "index [command]",
+		Short: "Index operations",
+	}
+
+	cmd.AddCommand(
+		createCmd(),
+	)
+	return cmd
+}

--- a/cmd/oras/root/manifest/index/cmd.go
+++ b/cmd/oras/root/manifest/index/cmd.go
@@ -27,6 +27,7 @@ func Cmd() *cobra.Command {
 
 	cmd.AddCommand(
 		createCmd(),
+		updateCmd(),
 	)
 	return cmd
 }

--- a/cmd/oras/root/manifest/index/create.go
+++ b/cmd/oras/root/manifest/index/create.go
@@ -75,6 +75,7 @@ Example - create an index from source manifests using both tags and digests,
 				return err
 			}
 			return option.Parse(cmd, &opts)
+			// todo: add EnsureReferenceNotEmpty somewhere
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return createIndex(cmd, opts)
@@ -143,9 +144,6 @@ func resolveSourceManifests(cmd *cobra.Command, destOpts createOptions, logger l
 		// prepare sourceTarget target
 		sourceTarget, err := source.NewReadonlyTarget(cmd.Context(), destOpts.Common, logger)
 		if err != nil {
-			return []ocispec.Descriptor{}, err
-		}
-		if err := source.EnsureReferenceNotEmpty(cmd, false); err != nil {
 			return []ocispec.Descriptor{}, err
 		}
 		var desc ocispec.Descriptor

--- a/cmd/oras/root/manifest/index/create.go
+++ b/cmd/oras/root/manifest/index/create.go
@@ -1,0 +1,159 @@
+package index
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/errdef"
+	"oras.land/oras-go/v2/registry"
+	"oras.land/oras/cmd/oras/internal/command"
+	oerrors "oras.land/oras/cmd/oras/internal/errors"
+	"oras.land/oras/cmd/oras/internal/option"
+	"oras.land/oras/internal/contentutil"
+)
+
+type createOptions struct {
+	option.Common
+	option.Target
+
+	sources []option.Target
+}
+
+func createCmd() *cobra.Command {
+	var opts createOptions
+	cmd := &cobra.Command{
+		Use:   "create [flags] --repo <repo-reference> <name>[:<tag>|@<digest>] [...]",
+		Short: "create and push an index from provided manifests",
+		Long: `create and push an index to a repository or an OCI image layout
+Example - create an index from source manifests tagged s1, s2, s3 in the repository
+ localhost:5000/hello, and push the index without tagging it :
+  oras index create --repo localhost:5000/hello s1 s2 s3
+Example - create an index from source manifests tagged s1, s2, s3 in the repository
+ localhost:5000/hello, and push the index with tag 'latest' :
+  oras index create --repo localhost:5000/hello --tag latest s1 s2 s3
+Example - create an index from source manifests using both tags and digests, 
+ and push the index with tag 'latest' :
+  oras index create --repo localhost:5000/hello --tag latest s1 sha256:xxx s3
+`,
+		Args: cobra.MinimumNArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// parse the target index reference
+			opts.RawReference = args[0]
+			repo, _, _ := strings.Cut(opts.RawReference, ":")
+
+			// parse the source manifests
+			opts.sources = make([]option.Target, len(args)-1)
+			for i, a := range args[1:] {
+				var ref string
+				if contentutil.IsDigest(a) {
+					ref = fmt.Sprintf("%s@%s", repo, a)
+				} else {
+					ref = fmt.Sprintf("%s:%s", repo, a)
+				}
+				m := option.Target{RawReference: ref, Remote: opts.Remote}
+				if err := m.Parse(cmd); err != nil {
+					return err
+				}
+				opts.sources[i] = m
+			}
+
+			return option.Parse(cmd, &opts)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return createIndex(cmd, opts)
+		},
+	}
+
+	option.ApplyFlags(&opts, cmd.Flags())
+	return oerrors.Command(cmd, &opts.Target)
+}
+
+func createIndex(cmd *cobra.Command, opts createOptions) error {
+	ctx, logger := command.GetLogger(cmd, &opts.Common)
+	dst, err := opts.NewTarget(opts.Common, logger)
+	if err != nil {
+		return err
+	}
+	// we assume that the sources and the to be created index are all in the same
+	// repository, so no copy is needed
+	manifests, err := resolveSourceManifests(cmd, opts, logger)
+	if err != nil {
+		return err
+	}
+	desc, reader := packIndex(manifests)
+	if err := pushIndex(ctx, dst, desc, opts.Reference, reader); err != nil {
+		return err
+	}
+	return nil
+}
+
+func resolveSourceManifests(cmd *cobra.Command, destOpts createOptions, logger logrus.FieldLogger) ([]ocispec.Descriptor, error) {
+	var resolved []ocispec.Descriptor
+	for _, source := range destOpts.sources {
+		var err error
+		// prepare sourceTarget target
+		sourceTarget, err := source.NewReadonlyTarget(cmd.Context(), destOpts.Common, logger)
+		if err != nil {
+			return []ocispec.Descriptor{}, err
+		}
+		if err := source.EnsureReferenceNotEmpty(cmd, false); err != nil {
+			return []ocispec.Descriptor{}, err
+		}
+		var desc ocispec.Descriptor
+		desc, err = oras.Resolve(cmd.Context(), sourceTarget, source.Reference, oras.DefaultResolveOptions)
+		if err != nil {
+			return []ocispec.Descriptor{}, fmt.Errorf("failed to resolve %s: %w", source.Reference, err)
+		}
+		resolved = append(resolved, desc)
+	}
+	return resolved, nil
+}
+
+func packIndex(manifests []ocispec.Descriptor) (ocispec.Descriptor, io.Reader) {
+	// todo: oras-go needs PackIndex
+	index := ocispec.Index{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2,
+		},
+		MediaType: ocispec.MediaTypeImageIndex,
+		Manifests: manifests,
+		// todo: annotations
+	}
+	content, _ := json.Marshal(index)
+	desc := ocispec.Descriptor{
+		Digest:    digest.FromBytes(content),
+		MediaType: ocispec.MediaTypeImageIndex,
+		Size:      int64(len(content)),
+	}
+	return desc, bytes.NewReader(content)
+}
+
+func pushIndex(ctx context.Context, dst oras.Target, desc ocispec.Descriptor, ref string, content io.Reader) error {
+	if refPusher, ok := dst.(registry.ReferencePusher); ok {
+		if ref != "" {
+			return refPusher.PushReference(ctx, desc, content, ref)
+		}
+	}
+	if err := dst.Push(ctx, desc, content); err != nil {
+		w := errors.Unwrap(err)
+		if w != errdef.ErrAlreadyExists {
+			return err
+		}
+	}
+	if ref == "" {
+		fmt.Println("Digest of the pushed index: ", desc.Digest)
+		return nil
+	}
+	return dst.Tag(ctx, desc, ref)
+}

--- a/cmd/oras/root/manifest/index/create.go
+++ b/cmd/oras/root/manifest/index/create.go
@@ -50,18 +50,18 @@ type createOptions struct {
 func createCmd() *cobra.Command {
 	var opts createOptions
 	cmd := &cobra.Command{
-		Use:   "create [flags] --repo <repo-reference> <name>[:<tag>|@<digest>] [...]",
+		Use:   "create [flags] <name>[:<tag>|@<digest>] [{<tag>|<digest>}...]",
 		Short: "create and push an index from provided manifests",
 		Long: `create and push an index to a repository or an OCI image layout
 Example - create an index from source manifests tagged s1, s2, s3 in the repository
  localhost:5000/hello, and push the index without tagging it :
-  oras index create --repo localhost:5000/hello s1 s2 s3
+  oras manifest index create localhost:5000/hello s1 s2 s3
 Example - create an index from source manifests tagged s1, s2, s3 in the repository
  localhost:5000/hello, and push the index with tag 'latest' :
-  oras index create --repo localhost:5000/hello --tag latest s1 s2 s3
+  oras manifest index create localhost:5000/hello:latest s1 s2 s3
 Example - create an index from source manifests using both tags and digests, 
  and push the index with tag 'latest' :
-  oras index create --repo localhost:5000/hello --tag latest s1 sha256:xxx s3
+  oras manifest index create localhost:5000/hello latest s1 sha256:xxx s3
 `,
 		Args: cobra.MinimumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -163,8 +163,9 @@ func fetchConfigDesc(ctx context.Context, src oras.ReadOnlyTarget, reference str
 		return ocispec.Descriptor{}, err
 	}
 
+	// if this manifest does not have a config
 	if !descriptor.IsImageManifest(manifestDesc) {
-		return ocispec.Descriptor{}, fmt.Errorf("%q is not an image manifest and does not have a config", manifestDesc.Digest)
+		return ocispec.Descriptor{}, nil
 	}
 
 	// unmarshal manifest content to extract config descriptor

--- a/cmd/oras/root/manifest/index/create.go
+++ b/cmd/oras/root/manifest/index/create.go
@@ -97,7 +97,7 @@ func createIndex(cmd *cobra.Command, opts createOptions) error {
 	if err != nil {
 		return err
 	}
-	desc, reader := packIndex(manifests)
+	desc, reader := packIndex(&ocispec.Index{}, manifests)
 	return pushIndex(ctx, dst, desc, opts.Reference, reader)
 }
 
@@ -183,14 +183,16 @@ func fetchConfigDesc(ctx context.Context, src oras.ReadOnlyTarget, reference str
 	return manifest.Config, nil
 }
 
-func packIndex(manifests []ocispec.Descriptor) (ocispec.Descriptor, io.Reader) {
+func packIndex(oldIndex *ocispec.Index, manifests []ocispec.Descriptor) (ocispec.Descriptor, io.Reader) {
 	index := ocispec.Index{
 		Versioned: specs.Versioned{
 			SchemaVersion: 2,
 		},
-		MediaType: ocispec.MediaTypeImageIndex,
-		Manifests: manifests,
-		// todo: annotations
+		MediaType:    ocispec.MediaTypeImageIndex,
+		ArtifactType: oldIndex.ArtifactType,
+		Manifests:    manifests,
+		Subject:      oldIndex.Subject,
+		Annotations:  oldIndex.Annotations,
 	}
 	content, _ := json.Marshal(index)
 	desc := ocispec.Descriptor{

--- a/cmd/oras/root/manifest/index/update.go
+++ b/cmd/oras/root/manifest/index/update.go
@@ -1,0 +1,167 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package index
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/spf13/cobra"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras/cmd/oras/internal/command"
+	oerrors "oras.land/oras/cmd/oras/internal/errors"
+	"oras.land/oras/cmd/oras/internal/option"
+	"oras.land/oras/internal/contentutil"
+)
+
+type updateOptions struct {
+	option.Common
+	option.Target
+
+	addArguments    []string
+	removeArguments []string
+	addTargets      []option.Target
+	removeTargets   []option.Target
+}
+
+func updateCmd() *cobra.Command {
+	var opts updateOptions
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "add or remove manifests from an image index",
+		Long:  `TBD`,
+		Args:  cobra.MinimumNArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			opts.RawReference = args[0]
+			repo, _, _ := strings.Cut(opts.RawReference, ":")
+
+			opts.addTargets = make([]option.Target, len(opts.addArguments))
+			// parse the add manifest arguments
+			for i, a := range opts.addArguments {
+				var ref string
+				if contentutil.IsDigest(a) {
+					ref = fmt.Sprintf("%s@%s", repo, a)
+				} else {
+					ref = fmt.Sprintf("%s:%s", repo, a)
+				}
+				opts.addArguments[i] = ref
+				m := option.Target{RawReference: ref, Remote: opts.Remote}
+				if err := m.Parse(cmd); err != nil {
+					return err
+				}
+				opts.addTargets[i] = m
+			}
+
+			return option.Parse(cmd, &opts)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return updateIndex(cmd, opts)
+		},
+	}
+	option.ApplyFlags(&opts, cmd.Flags())
+	cmd.Flags().StringArrayVarP(&opts.addArguments, "add", "", nil, "manifests to add to the index")
+	cmd.Flags().StringArrayVarP(&opts.removeArguments, "remove", "", nil, "manifests to remove from the index")
+
+	return oerrors.Command(cmd, &opts.Target)
+}
+
+func updateIndex(cmd *cobra.Command, opts updateOptions) error {
+	// fetch old index
+	ctx, logger := command.GetLogger(cmd, &opts.Common)
+	oldIndex, err := opts.NewTarget(opts.Common, logger)
+	if err != nil {
+		return err
+	}
+	desc, err := oras.Resolve(ctx, oldIndex, opts.Reference, oras.DefaultResolveOptions)
+	if err != nil {
+		return fmt.Errorf("failed to resolve %s: %w", opts.Reference, err)
+	}
+	contentBytes, err := content.FetchAll(ctx, oldIndex, desc)
+	if err != nil {
+		return err
+	}
+	var index ocispec.Index
+	if err := json.Unmarshal(contentBytes, &index); err != nil {
+		return err
+	}
+	manifests := index.Manifests
+
+	// resolve the index to add, need to get its platform information
+	for _, b := range opts.addTargets {
+		target, err := b.NewReadonlyTarget(ctx, opts.Common, logger)
+		if err != nil {
+			return err
+		}
+		if err := b.EnsureReferenceNotEmpty(cmd, false); err != nil {
+			return err
+		}
+		desc, err := oras.Resolve(ctx, target, b.Reference, oras.DefaultResolveOptions)
+		if err != nil {
+			return fmt.Errorf("failed to resolve %s: %w", b.Reference, err)
+		}
+		// detect platform information
+		// 1. fetch config descriptor
+		configDesc, err := fetchConfigDesc(ctx, target, b.Reference)
+		if err != nil {
+			return err
+		}
+		// 2. fetch config content
+		contentBytes, err := content.FetchAll(ctx, target, configDesc)
+		if err != nil {
+			return err
+		}
+		var config ocispec.Image
+		if err := json.Unmarshal(contentBytes, &config); err != nil {
+			return err
+		}
+		// 3. extract platform information
+		desc.Platform = &config.Platform
+
+		manifests = append(manifests, desc)
+	}
+
+	// pack the new index
+	newIndex := ocispec.Index{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2,
+		},
+		MediaType:    ocispec.MediaTypeImageIndex,
+		ArtifactType: index.ArtifactType,
+		Manifests:    manifests,
+		Subject:      index.Subject,
+		Annotations:  index.Annotations,
+		// todo: annotations
+	}
+	content, _ := json.Marshal(newIndex)
+	newDesc := ocispec.Descriptor{
+		Digest:    digest.FromBytes(content),
+		MediaType: ocispec.MediaTypeImageIndex,
+		Size:      int64(len(content)),
+	}
+	reader := bytes.NewReader(content)
+
+	// push the new index
+	if err := pushIndex(ctx, oldIndex, newDesc, opts.Reference, reader); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Proof of Concept demo for oras multi-arch feature support.

To test `oras manifest index create`:
to tag the final index:
`oras manifest index create myacr.azurecr.io/index-test:index00 s390x ppc64 sha256:56cb3f23d20f94c0dae83399335979bcee8dd365da306986400f0f7897eecbe8`

without tag:
`oras manifest index create myacr.azurecr.io/index-test s390x ppc64 sha256:56cb3f23d20f94c0dae83399335979bcee8dd365da306986400f0f7897eecbe8`

To test `oras manifest index update`:
`oras manifest index update myacr.azurecr.io/index-test:index00 --remove sha256:fd0201b8b0d7cdde2b9e8bcf5278b49668f1dd377a01ec1e2ef0e57382c25a0d --add amd64 --add arm64 --remove sha256:56cb3f23d20f94c0dae83399335979bcee8dd365da306986400f0f7897eecbe8`